### PR TITLE
ServiceモデルとUserモデルの関連付け

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
 
   def index
     if logged_in?
-      @services = Service.all
+      @services = current_user.services.all
     else
       render "welcome/index", layout: "welcome"
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,11 +4,11 @@ class ServicesController < ApplicationController
   before_action :load_service, only: %i(edit update destroy)
 
   def new
-    @service = Service.new
+    @service = current_user.services.build
   end
 
   def create
-    @service = Service.new(service_params)
+    @service = current_user.services.build(service_params)
     if @service.save
       redirect_to root_path, notice: "新しいサービスを登録しました。"
     else
@@ -43,6 +43,6 @@ class ServicesController < ApplicationController
     end
 
     def load_service
-      @service = Service.find(params[:id])
+      @service = current_user.services.find(params[:id])
     end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -3,6 +3,8 @@
 class Service < ApplicationRecord
   enum plan: { monthly: 0, yearly: 1 }
 
+  belongs_to :user
+
   validates :name, presence: true
   validates :plan, presence: true
   validates :price, numericality: { only_integer: true, allow_blank: true }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,9 @@
 
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :services, dependent: :destroy
 
   validates :password, length: { minimum: 6 }, confirmation: true, if: :password_required?
-
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true
 

--- a/db/migrate/20200122084229_add_user_id_to_services.rb
+++ b/db/migrate/20200122084229_add_user_id_to_services.rb
@@ -1,0 +1,10 @@
+class AddUserIdToServices < ActiveRecord::Migration[6.0]
+  def up
+    execute "DELETE FROM services;"
+    add_reference :services, :user, null: false, foreign_key: true, index: true
+  end
+
+  def down
+    remove_reference :services, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_12_063740) do
+ActiveRecord::Schema.define(version: 2020_01_22_084229) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +24,8 @@ ActiveRecord::Schema.define(version: 2020_01_12_063740) do
     t.date "notified_on"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -44,4 +45,6 @@ ActiveRecord::Schema.define(version: 2020_01_12_063740) do
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
+
+  add_foreign_key "services", "users"
 end

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -7,6 +7,7 @@ spotify:
   price: 980
   renewed_on: <%= Time.current + 1.month %>
   notified_on: <%= Time.current + 1.week %>
+  user: shoynoi
 
 amazonprime:
   name: Amazon Prime
@@ -15,6 +16,7 @@ amazonprime:
   price: 4800
   renewed_on: <%= Time.current + 3.month %>
   notified_on: <%= Time.current + 1.month %>
+  user: akira
 
 <% 5.times do |n| %>
 service_<%= n %>:
@@ -24,4 +26,5 @@ service_<%= n %>:
   price: 500
   renewed_on: 2019-01-10
   notified_on: 2019-01-05
+  user: shoynoi
 <% end %>

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -31,4 +31,12 @@ class ServiceTest < ActiveSupport::TestCase
     service.price = ""
     assert service.valid?
   end
+
+  test "when destroy a user, destroy services associated with a user" do
+    user = User.create!(name: "johndoe", email: "test@example.com", password: "secret", password_confirmation: "secret")
+    user.services.create!(name: "test service")
+    assert_difference "user.services.count", -1 do
+      user.destroy
+    end
+  end
 end

--- a/test/system/services_test.rb
+++ b/test/system/services_test.rb
@@ -9,11 +9,12 @@ class ServicesTest < ApplicationSystemTestCase
 
   test "create a new service" do
     visit new_service_path
-    fill_in "service_name", with: "テストサービス"
+    fill_in "service[name]", with: "テストサービス"
     select "月額", from: "プラン"
-    fill_in "service_price", with: 1200
-    fill_in "service_renewed_on", with: "2019/12/31"
-    fill_in "service_notified_on", with: "2019/12/20"
+    fill_in "service[price]", with: 1200
+    fill_in "service[renewed_on]", with: "2019/12/31"
+    fill_in "service[notified_on]", with: "2019/12/20"
+    fill_in "service[description]", with: "テストメモ"
     assert_difference "Service.count", 1 do
       click_on "登録"
       assert_text "サービスを登録しました。"
@@ -23,11 +24,12 @@ class ServicesTest < ApplicationSystemTestCase
   test "update a service" do
     service = services(:service_1)
     visit edit_service_path(service)
-    fill_in "service_name", with: "テストサービス(修正)"
+    fill_in "service[name]", with: "テストサービス(修正)"
     select "年額", from: "プラン"
-    fill_in "service_price", with: 1800
-    fill_in "service_renewed_on", with: "2020/1/10"
-    fill_in "service_notified_on", with: "2020/01/05"
+    fill_in "service[price]", with: 1800
+    fill_in "service[renewed_on]", with: "2020/1/10"
+    fill_in "service[notified_on]", with: "2020/01/05"
+    fill_in "service[description]", with: "テストメモ(修正)"
     click_on "修正"
     assert_text "サービスを修正しました。"
   end
@@ -42,6 +44,18 @@ class ServicesTest < ApplicationSystemTestCase
     end
     assert_difference "Service.count", -1 do
       assert_text "サービスを削除しました。"
+    end
+  end
+
+  test "only services associated with the user will be displayed" do
+    visit root_path
+    within(".list-group") do
+      assert_text "Spotify"
+    end
+    login_user "akira@example.com", "secret"
+    within(".list-group") do
+      assert_no_text "Spotify"
+      assert_text "Amazon Prime"
     end
   end
 end


### PR DESCRIPTION
Ref: #13

## 概要

- ServiceモデルとUserモデルのhas_many関連付けを設定
    - ユーザーが登録したサービスのみが一覧画面に表示されるようにした
    - テストを作成