### PR TITLE
登録サービス一覧ページにサービスの年間合計利用額と月平均利用額を表示

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -1,0 +1,36 @@
+.card-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  margin-top: 2rem
+}
+
+.card {
+  min-width: 10rem;
+  border-radius: 3px;
+  &--yellow {
+    background-color: #f6932b;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+  }
+  &--green {
+    background-color: #35AB45;
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
+  }
+}
+
+.card__body {
+  padding: .5rem;
+}
+
+.card__amount {
+  color: white;
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.card__title {
+  color: white;
+  font-size: .75rem;
+  text-align: center;
+  user-select: none;
+}

--- a/app/assets/stylesheets/_page-header.scss
+++ b/app/assets/stylesheets/_page-header.scss
@@ -2,7 +2,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: .5rem;
 }
 
 .page-header__actions {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
 @import "errors";
 @import "auth-form";
 @import "close-account";
+@import "card";

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,4 +8,17 @@ class Service < ApplicationRecord
   validates :name, presence: true
   validates :plan, presence: true
   validates :price, numericality: { only_integer: true, allow_blank: true }
+
+  def self.annual_total_amount
+    total_amount("yearly") + (total_amount("monthly") * 12)
+  end
+
+  def self.monthly_average_amount
+    annual_total_amount / 12
+  end
+
+  private
+    def self.total_amount(plan)
+      where(plan: plan).sum(:price)
+    end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -6,6 +6,20 @@ main.page
         i.fas.fa-plus-circle
         | 新規登録
 
+  .card-container
+    .card.card--yellow
+      .card__body
+        .card__title
+          | 月平均利用額
+        .card__amount
+          = number_to_currency(@services.monthly_average_amount)
+    .card.card--green
+      .card__body
+        .card__title
+          | 年間合計額
+        .card__amount
+          = number_to_currency(@services.annual_total_amount)
+
   .page-body
     h3.page-body__title 利用中のサービス
     .page-body__inner

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,9 @@
 ja:
+  number:
+    currency:
+      format:
+        unit: "¥"
+        format: "%u%n"
   activerecord:
     models:
       service: サービス

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -39,4 +39,20 @@ class ServiceTest < ActiveSupport::TestCase
       user.destroy
     end
   end
+
+  test "annual_total_amount" do
+    Service.delete_all
+    user = users(:shoynoi)
+    Service.create(name: "Spotify", plan: "monthly", price: 980, user: user)
+    Service.create(name: "Rubymine", plan: "yearly", price: 8000, user: user)
+    assert_equal 19760, user.services.annual_total_amount
+  end
+
+  test "monthly_average_amount" do
+    Service.delete_all
+    user = users(:shoynoi)
+    Service.create(name: "Spotify", plan: "monthly", price: 980, user: user)
+    Service.create(name: "Rubymine", plan: "yearly", price: 8000, user: user)
+    assert_equal 1646, user.services.monthly_average_amount
+  end
 end


### PR DESCRIPTION
Ref: #18 

## 概要

- サービス一覧ページ(トップページ)にユーザーの登録したサービスの年間合計利用額と月平均利用額を表示
- テストを追加