### PR TITLE
サービスリストの日付や料金のフォーマットを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "rails-i18n", "~> 6.0.0"
 gem "font-awesome-sass", "~> 5.12.0"
 gem "rails_autolink"
 gem "sorcery"
+gem "active_decorator"
 
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_decorator (1.3.2)
+      activesupport
     activejob (6.0.2.1)
       activesupport (= 6.0.2.1)
       globalid (>= 0.3.6)
@@ -260,6 +262,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_decorator
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module ServiceDecorator
+end

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 
 module ServiceDecorator
+  def formatted_notified_on
+    if Date.current.year == notified_on.year
+      I18n.l notified_on, format: :short
+    else
+      I18n.l notified_on
+    end
+  end
+
+  def formatted_renewed_on
+    if Date.current.year == renewed_on.year
+      I18n.l renewed_on, format: :short
+    else
+      I18n.l renewed_on
+    end
+  end
 end

--- a/app/views/services/_service.html.slim
+++ b/app/views/services/_service.html.slim
@@ -6,7 +6,7 @@
     .list__item.col-sm
       = t "activerecord.enums.service.plan.#{service.plan}"
     .list__item.col-sm
-      = service.price
+      = number_to_currency(service.price)
     .list__item
       - if service.renewed_on
         = service.formatted_renewed_on

--- a/app/views/services/_service.html.slim
+++ b/app/views/services/_service.html.slim
@@ -8,9 +8,11 @@
     .list__item.col-sm
       = service.price
     .list__item
-      = service.renewed_on
+      - if service.renewed_on
+        = service.formatted_renewed_on
     .list__item
-      = service.notified_on
+      - if service.notified_on
+        = service.formatted_notified_on
     .list__item.list__item--button.col-sm
       label.list__expand(for="service-#{service.id}")
   .list--expandable

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,8 @@
 ja:
+  date:
+    formats:
+      default: "%Y年%m月%d日"
+      short: "%-m月%-d日"
   number:
     currency:
       format:

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ServiceDecoratorTest < ActiveSupport::TestCase
+  def setup
+    @service = Service.new.extend ServiceDecorator
+  end
+
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class ServiceDecoratorTest < ActiveSupport::TestCase
   def setup
-    @service = Service.new.extend ServiceDecorator
+    @service = ActiveDecorator::Decorator.instance.decorate(services(:rubymine))
   end
 
-  # test "the truth" do
-  #   assert true
-  # end
+  test "format_date" do
+    travel_to Time.zone.local(2020, 12, 31) do
+      assert_equal "2021年01月26日", @service.formatted_renewed_on
+      assert_equal "12月31日", @service.formatted_notified_on
+    end
+  end
 end

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -18,6 +18,16 @@ amazonprime:
   notified_on: <%= Time.current + 1.month %>
   user: akira
 
+rubymine:
+  name: Rubymine
+  description: |
+    Visual Studio Codeに移行検討中。
+  plan: 1
+  price: 8000
+  renewed_on: 2021-01-26
+  notified_on: 2020-12-31
+  user: shoynoi
+
 <% 5.times do |n| %>
 service_<%= n %>:
   name: Service_<%= n %>


### PR DESCRIPTION
Ref: #20 

## 概要

- トップページのサービス一覧に表示されている日付のフォーマットを整えた
    - Active Decoratorを導入
    - 更新日や通知日が現在の年数と同じ場合、月と日のみを表示
    - 現在の年数ではないときには、年月日を表示
- サービスの料金に通貨を表示し、桁区切りを設定
- テストを追加