### PR TITLE
登録されたサービスが更新日を迎えたときにプランに応じて更新日を自動で更新するrakeタスクを作成

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class UserMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #
@@ -11,5 +12,12 @@ class UserMailer < ApplicationMailer
     @url  = edit_password_reset_url(@user.reset_password_token)
     mail(to: user.email,
          subject: "PreBill パスワードのリセット")
+  end
+
+  def renew_service(user)
+    @user = user
+    @services = user.services.renewal
+    mail(to: user.email,
+         subject: "PreBill 登録されたサービスが更新されました。")
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -14,9 +14,9 @@ class UserMailer < ApplicationMailer
          subject: "PreBill パスワードのリセット")
   end
 
-  def renew_service(user)
+  def renew_service(user, services)
     @user = user
-    @services = user.services.renewal
+    @services = services
     mail(to: user.email,
          subject: "PreBill 登録されたサービスが更新されました。")
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,7 +9,7 @@ class Service < ApplicationRecord
   validates :plan, presence: true
   validates :price, numericality: { only_integer: true, allow_blank: true }
 
-  scope :expired, -> { where("renewed_on < ?", Date.today) }
+  scope :renewal, -> { where(renewed_on: Date.today) }
 
   def self.annual_total_amount
     total_amount("yearly") + (total_amount("monthly") * 12)
@@ -17,6 +17,16 @@ class Service < ApplicationRecord
 
   def self.monthly_average_amount
     annual_total_amount / 12
+  end
+
+  def renew!
+    case plan
+    when "yearly"
+      self.renewed_on += 1.year
+    when "monthly"
+      self.renewed_on += 1.month
+    end
+    save!
   end
 
   private

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,6 +9,8 @@ class Service < ApplicationRecord
   validates :plan, presence: true
   validates :price, numericality: { only_integer: true, allow_blank: true }
 
+  scope :expired, -> { where("renewed_on < ?", Date.today) }
+
   def self.annual_total_amount
     total_amount("yearly") + (total_amount("monthly") * 12)
   end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,11 +22,10 @@ class Service < ApplicationRecord
   def renew!
     case plan
     when "yearly"
-      self.renewed_on += 1.year
+      update!(renewed_on: renewed_on.next_year)
     when "monthly"
-      self.renewed_on += 1.month
+      update!(renewed_on: renewed_on.next_month)
     end
-    save!
   end
 
   private

--- a/app/views/user_mailer/renew_service.html.erb
+++ b/app/views/user_mailer/renew_service.html.erb
@@ -1,0 +1,104 @@
+<!-- start hero -->
+<tr>
+  <td align="center" bgcolor="#FAFAFA">
+    <!--[if (gte mso 9)|(IE)]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+      <tr>
+        <td align="center" valign="top" width="600">
+    <![endif]-->
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+      <tr>
+        <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+          <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">サービスの更新通知</h1>
+        </td>
+      </tr>
+    </table>
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+  </td>
+</tr>
+<!-- end hero -->
+
+<!-- start copy block -->
+<tr>
+  <td align="center" bgcolor="#FAFAFA">
+    <!--[if (gte mso 9)|(IE)]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+      <tr>
+        <td align="center" valign="top" width="600">
+    <![endif]-->
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+      <!-- start copy -->
+      <tr>
+        <td align="left" bgcolor="#ffffff" style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+          <p style="margin: 0;">こんにちは、<%= @user.name %>さん。本日更新日を迎えたサービスをお知らせいたします。</p>
+          <p style="margin: 0;">以下の内容をご確認ください。</p>
+        </td>
+      </tr>
+      <!-- end copy -->
+
+      <!-- start receipt table -->
+      <tr>
+        <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td align="left" bgcolor="#D2C7BA" width="40%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>サービス名</strong></td>
+              <td align="left" bgcolor="#D2C7BA" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>プラン</strong></td>
+              <td align="left" bgcolor="#D2C7BA" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>料金</strong></td>
+              <td align="left" bgcolor="#D2C7BA" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>次回の更新日</strong></td>
+            </tr>
+            <% @services.each do |service| %>
+              <tr style="border-bottom: 2px dashed #D2C7BA;">
+                <td align="left" width="40%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= service.name %></td>
+                <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= t "activerecord.enums.service.plan.#{service.plan}"%></td>
+                <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= number_to_currency(service.price) %></td>
+                <td align="left" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= l service.renewed_on %></td>
+              </tr>
+            <% end %>
+          </table>
+        </td>
+      </tr>
+      <!-- end reeipt table -->
+
+      <!-- start button -->
+      <tr>
+        <td align="left" bgcolor="#ffffff">
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td align="center" bgcolor="#ffffff" style="padding: 12px 12px 28px;">
+                <table border="0" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td align="center" bgcolor="#1a82e2" style="border-radius: 24px;">
+                      <%= link_to "PreBIllへ", "#", style: "display: inline-block; padding: 14px 40px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 24px;", target: "_blank" %>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <!-- end button -->
+
+      <!-- start copy -->
+      <tr>
+        <td align="center" bgcolor="#ffffff" style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 24px; border-top: 1px solid #ddd">
+          <p style="margin: 0;"><%= link_to "メール配信を停止", "#" %></p>
+        </td>
+      </tr>
+      <!-- end copy -->
+
+    </table>
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+  </td>
+</tr>
+<!-- end copy block -->
+

--- a/app/views/user_mailer/renew_service.text.erb
+++ b/app/views/user_mailer/renew_service.text.erb
@@ -1,0 +1,16 @@
+こんにちは、<%= @user.name %>さん。
+本日更新日を迎えたサービスをお知らせいたします。
+以下の内容をご確認ください。
+
+  ======================================
+<% @services.each do |service| %>
+  サービス名: <%= service.name %>
+  プラン: <%= t "activerecord.enums.service.plan.#{service.plan}"%>
+  料金: <%= number_to_currency(service.price) %>
+  次回の更新日: <%= l service.renewed_on %>
+  ======================================
+<% end %>
+
+
+PreBill: https://example.com
+メール配信を停止: https://example.com

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -3,13 +3,9 @@
 namespace :notification do
   desc "Notify user to renewed service."
   task renewal: :environment do
-    services = Service.renewal
-    users = services.map(&:user).uniq
-    services.each do |service|
-      service.renew!
-    end
-    users.each do |user|
-      UserMailer.renew_service(user)
+    Service.renewal.includes(:user).group_by(&:user).each do |user, services|
+      services.each(&:renew!)
+      UserMailer.renew_service(user, services).deliver_now
     end
   end
 end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :notification do
+  desc "Notify user to renewed service."
+  task renewal: :environment do
+    services = Service.renewal
+    users = services.map(&:user).uniq
+    services.each do |service|
+      service.renew!
+    end
+    users.each do |user|
+      UserMailer.renew_service(user)
+    end
+  end
+end

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -9,7 +9,7 @@ class ServiceDecoratorTest < ActiveSupport::TestCase
 
   test "format_date" do
     travel_to Time.zone.local(2020, 12, 31) do
-      assert_equal "2021年01月26日", @service.formatted_renewed_on
+      assert_equal "2021年01月25日", @service.formatted_renewed_on
       assert_equal "12月31日", @service.formatted_notified_on
     end
   end

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -28,6 +28,16 @@ rubymine:
   notified_on: 2020-12-31
   user: shoynoi
 
+expired:
+  name: Renewed Service
+  description: |
+    更新日を迎えたサービス
+  plan: 0
+  price: 1000
+  renewed_on: 2018-10-10
+  user: inactive
+
+
 <% 5.times do |n| %>
 service_<%= n %>:
   name: Service_<%= n %>

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -16,7 +16,7 @@ amazonprime:
   price: 4800
   renewed_on: <%= Time.current + 3.month %>
   notified_on: <%= Time.current + 1.month %>
-  user: inactive
+  user: akira
 
 rubymine:
   name: Rubymine
@@ -36,3 +36,10 @@ renewal:
   price: 1000
   renewed_on: <%= Date.today %>
   user: shoynoi
+
+other_renewal:
+  name: Other Renewed Service
+  plan: 1
+  price: 2000
+  renewed_on: <%= Date.today %>
+  user: akira

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -16,7 +16,7 @@ amazonprime:
   price: 4800
   renewed_on: <%= Time.current + 3.month %>
   notified_on: <%= Time.current + 1.month %>
-  user: akira
+  user: inactive
 
 rubymine:
   name: Rubymine
@@ -24,27 +24,15 @@ rubymine:
     Visual Studio Codeに移行検討中。
   plan: 1
   price: 8000
-  renewed_on: 2021-01-26
+  renewed_on: 2021-01-25
   notified_on: 2020-12-31
   user: shoynoi
 
-expired:
+renewal:
   name: Renewed Service
   description: |
-    更新日を迎えたサービス
+    今日が更新日であるサービス
   plan: 0
   price: 1000
-  renewed_on: 2018-10-10
-  user: inactive
-
-
-<% 5.times do |n| %>
-service_<%= n %>:
-  name: Service_<%= n %>
-  description: memo...
-  plan: 0
-  price: 500
-  renewed_on: 2019-01-10
-  notified_on: 2019-01-05
+  renewed_on: <%= Date.today %>
   user: shoynoi
-<% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,14 @@ shoynoi:
   salt: <%= salt = "asdasdastr4325234324sdfds" %>
   crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>
 
-inactive:
+akira:
   name: akira
   email: akira@example.com
+  salt: <%= salt = "asdasdastr4325234324sdfds" %>
+  crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>
+
+inactive:
+  name: Inactive User
+  email: inactive@example.com
   salt: <%= salt = "asdasdastr4325234324sdfds" %>
   crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,7 +4,7 @@ shoynoi:
   salt: <%= salt = "asdasdastr4325234324sdfds" %>
   crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>
 
-akira:
+inactive:
   name: akira
   email: akira@example.com
   salt: <%= salt = "asdasdastr4325234324sdfds" %>

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class NotificationTest < ActiveSupport::TestCase
+  setup do
+    @monthly = services(:renewal)
+    @yearly = services(:other_renewal)
+    Prebill::Application.load_tasks
+    Rake::Task["notification:renewal"].execute
+  end
+
+  test "renew service" do
+    assert_equal Date.today.next_month, @monthly.reload.renewed_on
+    assert_equal Date.today.next_year, @yearly.reload.renewed_on
+    assert_equal ActionMailer::Base.deliveries.count, 2
+  end
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -8,4 +8,10 @@ class UserMailerPreview < ActionMailer::Preview
     user.generate_reset_password_token!
     UserMailer.reset_password_email(user)
   end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/renew_service
+  def renew_service
+    user = User.find_by(name: "shoynoi")
+    UserMailer.renew_service(user)
+  end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -36,4 +36,22 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match %r(こんにちは、#{user.name}さん。), mail.html_part.body.to_s
     assert_match %r(#{password_reset_url}), mail.html_part.body.to_s
   end
+
+  test "renew_service" do
+    user = users(:shoynoi)
+    services = [services(:renewal)]
+    mail = UserMailer.renew_service(user, services)
+
+    assert_emails 1 do
+      mail.deliver_now
+    end
+
+    assert_equal "PreBill 登録されたサービスが更新されました。", mail.subject
+    assert_equal ["shoynoi.jp@gmail.com"], mail.to
+    assert_equal ["info@prebill.com"], mail.from
+    assert_match %r(こんにちは、#{user.name}さん。本日更新日を迎えたサービスをお知らせいたします。), mail.html_part.body.to_s
+    assert_match %r(#{services.first.name}), mail.html_part.body.to_s
+    assert_match %r(こんにちは、#{user.name}さん。\r\n本日更新日を迎えたサービスをお知らせいたします。), mail.text_part.body.to_s
+    assert_match %r(#{services.first.name}), mail.text_part.body.to_s
+  end
 end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -4,30 +4,30 @@ require "test_helper"
 
 class ServiceTest < ActiveSupport::TestCase
   test "is valid" do
-    service = services(:service_1)
+    service = services(:spotify)
     assert service.valid?
   end
 
   test "is invalid when name is blank" do
-    service = services(:service_1)
+    service = services(:spotify)
     service.name = ""
     assert service.invalid?
   end
 
   test "is invalid when plan is blank" do
-    service = services(:service_1)
+    service = services(:spotify)
     service.plan = ""
     assert service.invalid?
   end
 
   test "is invalid when price is not Integer" do
-    service = services(:service_1)
+    service = services(:spotify)
     service.price = "980円"
     assert service.invalid?
   end
 
   test "is valid when price is blank" do
-    service = services(:service_1)
+    service = services(:spotify)
     service.price = ""
     assert service.valid?
   end
@@ -41,16 +41,14 @@ class ServiceTest < ActiveSupport::TestCase
   end
 
   test "annual_total_amount" do
-    Service.delete_all
-    user = users(:shoynoi)
+    user = users(:inactive)
     Service.create(name: "Spotify", plan: "monthly", price: 980, user: user)
     Service.create(name: "Rubymine", plan: "yearly", price: 8000, user: user)
     assert_equal 19760, user.services.annual_total_amount
   end
 
   test "monthly_average_amount" do
-    Service.delete_all
-    user = users(:shoynoi)
+    user = users(:inactive)
     Service.create(name: "Spotify", plan: "monthly", price: 980, user: user)
     Service.create(name: "Rubymine", plan: "yearly", price: 8000, user: user)
     assert_equal 1646, user.services.monthly_average_amount

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -55,4 +55,21 @@ class ServiceTest < ActiveSupport::TestCase
     Service.create(name: "Rubymine", plan: "yearly", price: 8000, user: user)
     assert_equal 1646, user.services.monthly_average_amount
   end
+
+  test "renew!" do
+    user = users(:shoynoi)
+    monthly_service = Service.create(name: "Monthly Subscription", plan: "monthly", renewed_on: Date.today, user: user)
+    yearly_service = Service.create(name: "Yearly Subscription", plan: "yearly", renewed_on: Date.today, user: user)
+    assert_changes -> { monthly_service.renewed_on }, from: Date.today, to: Date.today.next_month do
+      monthly_service.renew!
+    end
+    assert_changes -> { yearly_service.renewed_on }, from: Date.today, to: Date.today.next_year do
+      yearly_service.renew!
+    end
+  end
+
+  test "renewal" do
+    renewal_services = services(:renewal, :other_renewal)
+    assert_equal Service.renewal, renewal_services
+  end
 end

--- a/test/system/services_test.rb
+++ b/test/system/services_test.rb
@@ -22,7 +22,7 @@ class ServicesTest < ApplicationSystemTestCase
   end
 
   test "update a service" do
-    service = services(:service_1)
+    service = services(:spotify)
     visit edit_service_path(service)
     fill_in "service[name]", with: "テストサービス(修正)"
     select "年額", from: "プラン"


### PR DESCRIPTION
Ref: #22 

## 概要

- サービスの更新日にプラン(月額/年額)に応じて自動で更新日をアップデートするRakeタスクを作成
- 更新日を迎えたときにメールを送信する機能を追加
    - ユーザーが当日が更新日であるサービスを複数登録していた場合でも1通のメールにまとめて送信できるようにした
- テストを作成