### PR TITLE
更新日を迎えたサービスのメール通知を受け取るか否かを設定できる機能を追加

### DIFF
--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -17,6 +17,10 @@
 .form-item {
   margin-bottom: 1.5rem;
   display: flex;
+  &--checkbox {
+    align-items: center;
+    order: 1;
+  }
 }
 
 .form-item__help {
@@ -42,6 +46,10 @@
   padding-top: 9px;
   padding-right: 2rem;
   width: 7rem;
+  &--checkbox {
+    font-weight: 600;
+    font-size: 0.875rem;
+  }
 }
 
 .form-item__label--block {
@@ -119,6 +127,7 @@
 
 .form-item__remember-me {
   font-size: .85rem;
+  margin-right: .3rem;
 }
 
 .form-item__checkbox {

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -32,6 +32,7 @@ class MyAccountController < ApplicationController
         :email,
         :password,
         :password_confirmation,
+        :mail_notification,
         )
     end
 end

--- a/app/views/my_account/edit.html.slim
+++ b/app/views/my_account/edit.html.slim
@@ -5,7 +5,7 @@ main.page
   .page-body
     .auth-form--is-update
       .auth-form__body
-        = render "users/form", user: @user, url: my_account_path
+        = render "users/form", form: :edit, user: @user, url: my_account_path
       footer.auth-form__footer
         nav.auth-form-nav
           ul.auth-form-nav__items

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -7,6 +7,11 @@
     .form-item--block
       = f.label :email, class: "form-item__label--block"
       = f.email_field :email, class: "form-item__text-input--block", placeholder: "Eメール"
+    - if form == :edit
+      .form-item--block
+        = f.label :mail_notification, class: "form-item__label--checkbox" do
+          = f.check_box :mail_notification, class: "form-item__checkbox"
+          | 更新日にメールで通知を受け取る
     .form-item--block
       = f.label :password, class: "form-item__label--block"
       = f.password_field :password, class: "form-item__text-input--block", placeholder: "パスワード"

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -4,7 +4,7 @@ h1.auth-form-logo
   header.auth-form__header
     h1.auth-form__title ユーザー登録
   .auth-form__body
-    = render "form", user: @user, url: signup_path
+    = render "form", form: :new, user: @user, url: signup_path
   footer.auth-form__footer
     nav.auth-form-nav
       ul.auth-form-nav__items

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,6 +27,7 @@ ja:
         email: メールアドレス
         password: パスワード
         password_confirmation: パスワード(確認)
+        mail_notification: メール通知
     enums:
       service:
         plan:

--- a/db/migrate/20200130122930_add_mail_notification_to_users.rb
+++ b/db/migrate/20200130122930_add_mail_notification_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMailNotificationToUsers < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :mail_notification, :boolean, default: false, null: false

--- a/db/migrate/20200130122930_add_mail_notification_to_users.rb
+++ b/db/migrate/20200130122930_add_mail_notification_to_users.rb
@@ -1,0 +1,5 @@
+class AddMailNotificationToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :mail_notification, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_084229) do
+ActiveRecord::Schema.define(version: 2020_01_30_122930) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +41,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_084229) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.boolean "mail_notification", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_01_30_122930) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -5,7 +5,7 @@ namespace :notification do
   task renewal: :environment do
     Service.renewal.includes(:user).group_by(&:user).each do |user, services|
       services.each(&:renew!)
-      UserMailer.renew_service(user, services).deliver_now
+      UserMailer.renew_service(user, services).deliver_now if user.mail_notification
     end
   end
 end

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -34,12 +34,12 @@ renewal:
     今日が更新日であるサービス
   plan: 0
   price: 1000
-  renewed_on: <%= Date.today %>
+  renewed_on: 2020-01-31
   user: shoynoi
 
 other_renewal:
   name: Other Renewed Service
   plan: 1
   price: 2000
-  renewed_on: <%= Date.today %>
+  renewed_on: 2020-01-31
   user: akira

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,15 +3,18 @@ shoynoi:
   email: shoynoi.jp@gmail.com
   salt: <%= salt = "asdasdastr4325234324sdfds" %>
   crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>
+  mail_notification: true
 
 akira:
   name: akira
   email: akira@example.com
   salt: <%= salt = "asdasdastr4325234324sdfds" %>
   crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>
+  mail_notification: true
 
 inactive:
   name: Inactive User
   email: inactive@example.com
   salt: <%= salt = "asdasdastr4325234324sdfds" %>
   crypted_password: <%= Sorcery::CryptoProviders::BCrypt.encrypt("secret", salt) %>
+  mail_notification: false

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -4,15 +4,27 @@ require "test_helper"
 
 class NotificationTest < ActiveSupport::TestCase
   setup do
-    @monthly = services(:renewal)
-    @yearly = services(:other_renewal)
     Prebill::Application.load_tasks
-    Rake::Task["notification:renewal"].execute
   end
 
   test "renew service" do
-    assert_equal Date.today.next_month, @monthly.reload.renewed_on
-    assert_equal Date.today.next_year, @yearly.reload.renewed_on
-    assert_equal ActionMailer::Base.deliveries.count, 2
+    monthly = services(:renewal)
+    yearly = services(:other_renewal)
+    travel_to Time.zone.parse("2020-01-31") do
+      Rake::Task["notification:renewal"].execute
+      assert_equal Date.parse("2020-02-29"), monthly.reload.renewed_on
+      assert_equal Date.parse("2021-01-31"), yearly.reload.renewed_on
+      assert_equal ActionMailer::Base.deliveries.count, 2
+    end
+  end
+
+  test "do not send mail if user do not want to receive" do
+    user = users(:inactive)
+    service = user.services.create(name: "No notification", plan: 0, renewed_on: "2020-10-10")
+    travel_to Time.zone.parse("2020-10-10") do
+      Rake::Task["notification:renewal"].execute
+      assert_equal Date.parse("2020-11-10"), service.reload.renewed_on
+      assert_equal ActionMailer::Base.deliveries.count, 0
+    end
   end
 end

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -68,6 +68,8 @@ class ServiceTest < ActiveSupport::TestCase
 
   test "renewal" do
     renewal_services = services(:renewal, :other_renewal)
-    assert_equal Service.renewal, renewal_services
+    travel_to Time.zone.parse("2020-01-31") do
+      assert_equal Service.renewal, renewal_services
+    end
   end
 end


### PR DESCRIPTION
Ref: #24 

## 概要

- ユーザーが登録しているサービスが更新日を迎えたときにメール通知を受け取るか否かを設定できる項目をユーザー設定フォームに追加
- テストを作成