### PR TITLE
通知日にメールで通知する機能を追加

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -39,7 +39,7 @@ class ServicesController < ApplicationController
         :plan,
         :price,
         :renewed_on,
-        :notified_on)
+        :remind_on)
     end
 
     def load_service

--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module ServiceDecorator
-  def formatted_notified_on
-    if Date.current.year == notified_on.year
-      I18n.l notified_on, format: :short
+  def formatted_remind_on
+    if Date.current.year == remind_on.year
+      I18n.l remind_on, format: :short
     else
-      I18n.l notified_on
+      I18n.l remind_on
     end
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,4 +20,11 @@ class UserMailer < ApplicationMailer
     mail(to: user.email,
          subject: "PreBill 登録されたサービスが更新されました。")
   end
+
+  def remind_services(user, services)
+    @user = user
+    @services = services
+    mail(to: user.email,
+         subject: "PreBill サービス更新のリマインド")
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,6 +10,7 @@ class Service < ApplicationRecord
   validates :price, numericality: { only_integer: true, allow_blank: true }
 
   scope :renewal, -> { where(renewed_on: Date.today) }
+  scope :notice, -> { where(remind_on: Date.today) }
 
   def self.annual_total_amount
     total_amount("yearly") + (total_amount("monthly") * 12)

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,7 +10,7 @@ class Service < ApplicationRecord
   validates :price, numericality: { only_integer: true, allow_blank: true }
 
   scope :renewal, -> { where(renewed_on: Date.today) }
-  scope :notice, -> { where(remind_on: Date.today) }
+  scope :remind, -> { where(remind_on: Date.today) }
 
   def self.annual_total_amount
     total_amount("yearly") + (total_amount("monthly") * 12)

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -34,7 +34,7 @@ main.page
           .list-group__label
             = Service.human_attribute_name(:renewed_on)
           .list-group__label
-            = Service.human_attribute_name(:notified_on)
+            = Service.human_attribute_name(:remind_on)
           .list-group__label.col-sm
         .list-group__inner
           = render partial: "services/service", collection: @services, as: :service

--- a/app/views/services/_form.html.slim
+++ b/app/views/services/_form.html.slim
@@ -16,8 +16,8 @@
       = f.label :renewed_on, class: "form-item__label"
       = f.date_field :renewed_on, class: "form-item__text-input"
     .form-item
-      = f.label :notified_on, class: "form-item__label"
-      = f.date_field :notified_on, class: "form-item__text-input"
+      = f.label :remind_on, class: "form-item__label"
+      = f.date_field :remind_on, class: "form-item__text-input"
     .form-item
       = f.label :description, class: "form-item__label"
       = f.text_area :description, class: "form-item__textarea"

--- a/app/views/services/_service.html.slim
+++ b/app/views/services/_service.html.slim
@@ -11,8 +11,8 @@
       - if service.renewed_on
         = service.formatted_renewed_on
     .list__item
-      - if service.notified_on
-        = service.formatted_notified_on
+      - if service.remind_on
+        = service.formatted_remind_on
     .list__item.list__item--button.col-sm
       label.list__expand(for="service-#{service.id}")
   .list--expandable

--- a/app/views/user_mailer/remind_services.html.erb
+++ b/app/views/user_mailer/remind_services.html.erb
@@ -1,0 +1,104 @@
+<!-- start hero -->
+<tr>
+  <td align="center" bgcolor="#FAFAFA">
+    <!--[if (gte mso 9)|(IE)]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+      <tr>
+        <td align="center" valign="top" width="600">
+    <![endif]-->
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+      <tr>
+        <td align="left" bgcolor="#ffffff" style="padding: 36px 24px 0; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; border-top: 3px solid #d4dadf;">
+          <h1 style="margin: 0; font-size: 32px; font-weight: 700; letter-spacing: -1px; line-height: 48px;">サービスの更新日が近づいています</h1>
+        </td>
+      </tr>
+    </table>
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+  </td>
+</tr>
+<!-- end hero -->
+
+<!-- start copy block -->
+<tr>
+  <td align="center" bgcolor="#FAFAFA">
+    <!--[if (gte mso 9)|(IE)]>
+    <table align="center" border="0" cellpadding="0" cellspacing="0" width="600">
+      <tr>
+        <td align="center" valign="top" width="600">
+    <![endif]-->
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px;">
+
+      <!-- start copy -->
+      <tr>
+        <td align="left" bgcolor="#ffffff" style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+          <p style="margin: 0;">こんにちは、<%= @user.name %>さん。登録されているサブスクリプションがもうすぐ更新されます。</p>
+          <p style="margin: 0;">更新日をご確認ください。</p>
+        </td>
+      </tr>
+      <!-- end copy -->
+
+      <!-- start receipt table -->
+      <tr>
+        <td align="left" bgcolor="#ffffff" style="padding: 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;">
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td align="left" bgcolor="#D2C7BA" width="40%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>サービス名</strong></td>
+              <td align="left" bgcolor="#D2C7BA" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>プラン</strong></td>
+              <td align="left" bgcolor="#D2C7BA" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>料金</strong></td>
+              <td align="left" bgcolor="#D2C7BA" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><strong>更新日</strong></td>
+            </tr>
+            <% @services.each do |service| %>
+              <tr style="border-bottom: 2px dashed #D2C7BA;">
+                <td align="left" width="40%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= service.name %></td>
+                <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= t "activerecord.enums.service.plan.#{service.plan}"%></td>
+                <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= number_to_currency(service.price) %></td>
+                <td align="left" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= l service.renewed_on %></td>
+              </tr>
+            <% end %>
+          </table>
+        </td>
+      </tr>
+      <!-- end reeipt table -->
+
+      <!-- start button -->
+      <tr>
+        <td align="left" bgcolor="#ffffff">
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td align="center" bgcolor="#ffffff" style="padding: 12px 12px 28px;">
+                <table border="0" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td align="center" bgcolor="#1a82e2" style="border-radius: 24px;">
+                      <%= link_to "PreBIllへ", "#", style: "display: inline-block; padding: 14px 40px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; color: #ffffff; text-decoration: none; border-radius: 24px;", target: "_blank" %>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <!-- end button -->
+
+      <!-- start copy -->
+      <tr>
+        <td align="center" bgcolor="#ffffff" style="padding: 12px 24px; font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 12px; line-height: 24px; border-top: 1px solid #ddd">
+          <p style="margin: 0;"><%= link_to "メール配信を停止", "#" %></p>
+        </td>
+      </tr>
+      <!-- end copy -->
+
+    </table>
+    <!--[if (gte mso 9)|(IE)]>
+    </td>
+    </tr>
+    </table>
+    <![endif]-->
+  </td>
+</tr>
+<!-- end copy block -->
+

--- a/app/views/user_mailer/remind_services.text.erb
+++ b/app/views/user_mailer/remind_services.text.erb
@@ -1,0 +1,16 @@
+こんにちは、<%= @user.name %>さん。
+登録されているサブスクリプションがもうすぐ更新されます。
+更新日をご確認ください。
+
+======================================
+<% @services.each do |service| %>
+  サービス名: <%= service.name %>
+  プラン: <%= t "activerecord.enums.service.plan.#{service.plan}"%>
+  料金: <%= number_to_currency(service.price) %>
+  更新日: <%= l service.renewed_on %>
+  ======================================
+<% end %>
+
+
+PreBill: https://example.com
+メール配信を停止: https://example.com

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,7 +18,7 @@ ja:
         plan: プラン
         price: 料金
         renewed_on: 更新日
-        notified_on: 通知日
+        remind_on: 通知日
         description: メモ
         created_at: 作成日時
         updated_at: 更新日時

--- a/db/migrate/20200201040305_rename_notified_on_to_services.rb
+++ b/db/migrate/20200201040305_rename_notified_on_to_services.rb
@@ -1,0 +1,5 @@
+class RenameNotifiedOnToServices < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :services, :notified_on, :remind_on
+  end
+end

--- a/db/migrate/20200201040305_rename_notified_on_to_services.rb
+++ b/db/migrate/20200201040305_rename_notified_on_to_services.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameNotifiedOnToServices < ActiveRecord::Migration[6.0]
   def change
     rename_column :services, :notified_on, :remind_on

--- a/db/migrate/20200202053618_add_remind_sent_at_to_users.rb
+++ b/db/migrate/20200202053618_add_remind_sent_at_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRemindSentAtToUsers < ActiveRecord::Migration[6.0]
   def change
     add_column :users, :remind_sent_at, :datetime

--- a/db/migrate/20200202053618_add_remind_sent_at_to_users.rb
+++ b/db/migrate/20200202053618_add_remind_sent_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddRemindSentAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :remind_sent_at, :datetime
+    add_index :users, :remind_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_01_040305) do
+ActiveRecord::Schema.define(version: 2020_02_02_053618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 2020_02_01_040305) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
+    t.datetime "remind_sent_at"
+    t.index ["remind_sent_at"], name: "index_services_on_remind_sent_at"
     t.index ["renewed_on"], name: "index_services_on_renewed_on"
     t.index ["user_id"], name: "index_services_on_user_id"
   end
@@ -43,8 +45,10 @@ ActiveRecord::Schema.define(version: 2020_02_01_040305) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.boolean "mail_notification", default: false, null: false
+    t.datetime "remind_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
+    t.index ["remind_sent_at"], name: "index_users_on_remind_sent_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_02_02_053618) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_025946) do
+ActiveRecord::Schema.define(version: 2020_02_01_040305) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_01_31_025946) do
     t.integer "plan", default: 0, null: false
     t.integer "price"
     t.date "renewed_on"
-    t.date "notified_on"
+    t.date "remind_on"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -9,9 +9,13 @@ namespace :notification do
     end
   end
 
+  desc "Notify user to remind service."
   task remind: :environment do
     Service.remind.includes(:user).group_by(&:user).each do |user, services|
-      UserMailer.remind_services(user, services).deliver_now
+      unless user.remind_sent_at.try(:between?, Date.today.beginning_of_day, Date.today.end_of_day)
+        UserMailer.remind_services(user, services).deliver_now
+        user.touch(:remind_sent_at)
+      end
     end
   end
 end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -8,4 +8,10 @@ namespace :notification do
       UserMailer.renew_service(user, services).deliver_now if user.mail_notification
     end
   end
+
+  task remind: :environment do
+    Service.remind.includes(:user).group_by(&:user).each do |user, services|
+      UserMailer.remind_services(user, services).deliver_now
+    end
+  end
 end

--- a/test/decorators/service_decorator_test.rb
+++ b/test/decorators/service_decorator_test.rb
@@ -10,7 +10,7 @@ class ServiceDecoratorTest < ActiveSupport::TestCase
   test "format_date" do
     travel_to Time.zone.local(2020, 12, 31) do
       assert_equal "2021年01月25日", @service.formatted_renewed_on
-      assert_equal "12月31日", @service.formatted_notified_on
+      assert_equal "12月31日", @service.formatted_remind_on
     end
   end
 end

--- a/test/fixtures/services.yml
+++ b/test/fixtures/services.yml
@@ -6,7 +6,7 @@ spotify:
   plan: 0
   price: 980
   renewed_on: <%= Time.current + 1.month %>
-  notified_on: <%= Time.current + 1.week %>
+  remind_on: <%= Time.current + 1.week %>
   user: shoynoi
 
 amazonprime:
@@ -15,7 +15,7 @@ amazonprime:
   plan: 1
   price: 4800
   renewed_on: <%= Time.current + 3.month %>
-  notified_on: <%= Time.current + 1.month %>
+  remind_on: <%= Time.current + 1.month %>
   user: akira
 
 rubymine:
@@ -25,7 +25,7 @@ rubymine:
   plan: 1
   price: 8000
   renewed_on: 2021-01-25
-  notified_on: 2020-12-31
+  remind_on: 2020-12-31
   user: shoynoi
 
 renewal:

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -27,4 +27,11 @@ class NotificationTest < ActiveSupport::TestCase
       assert_equal ActionMailer::Base.deliveries.count, 0
     end
   end
+
+  test "remind services" do
+    travel_to Time.zone.parse("2020-12-31") do
+      Rake::Task["notification:remind"].execute
+      assert_equal ActionMailer::Base.deliveries.count, 1
+    end
+  end
 end

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -34,4 +34,14 @@ class NotificationTest < ActiveSupport::TestCase
       assert_equal ActionMailer::Base.deliveries.count, 1
     end
   end
+
+  test "do not send emails to reminded users" do
+    travel_to Time.zone.parse("2020-12-31") do
+      Rake::Task["notification:remind"].execute
+      assert_equal ActionMailer::Base.deliveries.count, 1
+      ActionMailer::Base.deliveries.clear
+      Rake::Task["notification:remind"].execute
+      assert_equal ActionMailer::Base.deliveries.count, 0
+    end
+  end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -14,4 +14,11 @@ class UserMailerPreview < ActionMailer::Preview
     user = User.find_by(name: "shoynoi")
     UserMailer.renew_service(user)
   end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/remind_services
+  def remind_services
+    user = User.find_by(name: "shoynoi")
+    services = user.services.remind
+    UserMailer.remind_services(user, services)
+  end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -12,7 +12,8 @@ class UserMailerPreview < ActionMailer::Preview
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/renew_service
   def renew_service
     user = User.find_by(name: "shoynoi")
-    UserMailer.renew_service(user)
+    services = user.services.renewal
+    UserMailer.renew_service(user, services)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/remind_services

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -54,4 +54,22 @@ class UserMailerTest < ActionMailer::TestCase
     assert_match %r(こんにちは、#{user.name}さん。\r\n本日更新日を迎えたサービスをお知らせいたします。), mail.text_part.body.to_s
     assert_match %r(#{services.first.name}), mail.text_part.body.to_s
   end
+
+  test "remind_services" do
+    user = users(:shoynoi)
+    services = [services(:rubymine)]
+    mail = UserMailer.remind_services(user, services)
+
+    assert_emails 1 do
+      mail.deliver_now
+    end
+
+    assert_equal "PreBill サービス更新のリマインド", mail.subject
+    assert_equal ["shoynoi.jp@gmail.com"], mail.to
+    assert_equal ["info@prebill.com"], mail.from
+    assert_match %r(こんにちは、#{user.name}さん。登録されているサブスクリプションがもうすぐ更新されます。), mail.html_part.body.to_s
+    assert_match %r(Rubymine), mail.html_part.body.to_s
+    assert_match %r(こんにちは、#{user.name}さん。\r\n登録されているサブスクリプションがもうすぐ更新されます。), mail.text_part.body.to_s
+    assert_match %r(Rubymine), mail.text_part.body.to_s
+  end
 end

--- a/test/system/services_test.rb
+++ b/test/system/services_test.rb
@@ -13,7 +13,7 @@ class ServicesTest < ApplicationSystemTestCase
     select "月額", from: "プラン"
     fill_in "service[price]", with: 1200
     fill_in "service[renewed_on]", with: "2019/12/31"
-    fill_in "service[notified_on]", with: "2019/12/20"
+    fill_in "service[remind_on]", with: "2019/12/20"
     fill_in "service[description]", with: "テストメモ"
     assert_difference "Service.count", 1 do
       click_on "登録"
@@ -28,7 +28,7 @@ class ServicesTest < ApplicationSystemTestCase
     select "年額", from: "プラン"
     fill_in "service[price]", with: 1800
     fill_in "service[renewed_on]", with: "2020/1/10"
-    fill_in "service[notified_on]", with: "2020/01/05"
+    fill_in "service[remind_on]", with: "2020/01/05"
     fill_in "service[description]", with: "テストメモ(修正)"
     click_on "修正"
     assert_text "サービスを修正しました。"


### PR DESCRIPTION
Ref: #27 

## 概要

- 登録されたサービスの通知日にメールで通知を送信する機能を追加
    - ユーザーモデルに`remind_sent_at`カラム(datetime)を追加し、その日に通知されたユーザーに対しては再度メールが送信されないようにした。
- Serviceモデルの`notified_on`を`remind_on`にリネーム
- テストを追加