### PR TITLE
サービスのrenewed_onから次回の更新日を算出するように修正

### DIFF
--- a/app/decorators/service_decorator.rb
+++ b/app/decorators/service_decorator.rb
@@ -11,9 +11,9 @@ module ServiceDecorator
 
   def formatted_renewed_on
     if Date.current.year == renewed_on.year
-      I18n.l renewed_on, format: :short
+      I18n.l next_renewed_on, format: :short
     else
-      I18n.l renewed_on
+      I18n.l next_renewed_on
     end
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -9,7 +9,6 @@ class Service < ApplicationRecord
   validates :plan, presence: true
   validates :price, numericality: { only_integer: true, allow_blank: true }
 
-  scope :renewal, -> { where(renewed_on: Date.today) }
   scope :remind, -> { where(remind_on: Date.today) }
 
   def self.annual_total_amount
@@ -20,17 +19,47 @@ class Service < ApplicationRecord
     annual_total_amount / 12
   end
 
-  def renew!
+  def self.renewal
+    Service.select { |service| service.next_renewed_on == Date.today }
+  end
+
+  def next_renewed_on(n = 0)
     case plan
-    when "yearly"
-      update!(renewed_on: renewed_on.next_year)
     when "monthly"
-      update!(renewed_on: renewed_on.next_month)
+      renewed_on.next_month(number_of_renewal + n)
+    when "yearly"
+      renewed_on.next_year(number_of_renewal + n)
     end
   end
 
   private
     def self.total_amount(plan)
       where(plan: plan).sum(:price)
+    end
+
+    def elapsed_months
+      today = Date.today
+      return 0 if today <= renewed_on
+      elapsed_months = (today.year - renewed_on.year) * 12 + (today.month - renewed_on.month) + 1
+      if renewed_on.day < today.day || today.day == Time.days_in_month(today.month) && today.day < renewed_on.day
+        elapsed_months
+      else
+        elapsed_months - 1
+      end
+    end
+
+    def elapsed_years
+      today = Date.today
+      return 0 if today <= renewed_on
+      elapsed_months / 12 + 1
+    end
+
+    def number_of_renewal
+      case plan
+      when "monthly"
+        elapsed_months
+      when "yearly"
+        elapsed_years
+      end
     end
 end

--- a/app/views/user_mailer/remind_services.html.erb
+++ b/app/views/user_mailer/remind_services.html.erb
@@ -56,7 +56,7 @@
                 <td align="left" width="40%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= service.name %></td>
                 <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= t "activerecord.enums.service.plan.#{service.plan}"%></td>
                 <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= number_to_currency(service.price) %></td>
-                <td align="left" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= l service.renewed_on %></td>
+                <td align="left" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= l service.next_renewed_on(1) %></td>
               </tr>
             <% end %>
           </table>

--- a/app/views/user_mailer/remind_services.text.erb
+++ b/app/views/user_mailer/remind_services.text.erb
@@ -7,7 +7,7 @@
   サービス名: <%= service.name %>
   プラン: <%= t "activerecord.enums.service.plan.#{service.plan}"%>
   料金: <%= number_to_currency(service.price) %>
-  更新日: <%= l service.renewed_on %>
+  更新日: <%= l service.next_renewed_on(1) %>
   ======================================
 <% end %>
 

--- a/app/views/user_mailer/renew_service.html.erb
+++ b/app/views/user_mailer/renew_service.html.erb
@@ -56,7 +56,7 @@
                 <td align="left" width="40%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= service.name %></td>
                 <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= t "activerecord.enums.service.plan.#{service.plan}"%></td>
                 <td align="left" width="15%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= number_to_currency(service.price) %></td>
-                <td align="left" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= l service.renewed_on %></td>
+                <td align="left" width="30%" style="padding: 12px;font-family: 'Source Sans Pro', Helvetica, Arial, sans-serif; font-size: 16px; line-height: 24px;"><%= l service.next_renewed_on(1) %></td>
               </tr>
             <% end %>
           </table>

--- a/app/views/user_mailer/renew_service.text.erb
+++ b/app/views/user_mailer/renew_service.text.erb
@@ -7,7 +7,7 @@
   サービス名: <%= service.name %>
   プラン: <%= t "activerecord.enums.service.plan.#{service.plan}"%>
   料金: <%= number_to_currency(service.price) %>
-  次回の更新日: <%= l service.renewed_on %>
+  次回の更新日: <%= l service.next_renewed_on(1) %>
   ======================================
 <% end %>
 

--- a/db/migrate/20200220043306_add_renewal_sent_at_to_users.rb
+++ b/db/migrate/20200220043306_add_renewal_sent_at_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRenewalSentAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :renewal_sent_at, :datetime
+    add_index :users, :renewal_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_02_02_053618) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,8 +25,6 @@ ActiveRecord::Schema.define(version: 2020_02_02_053618) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
-    t.datetime "remind_sent_at"
-    t.index ["remind_sent_at"], name: "index_services_on_remind_sent_at"
     t.index ["renewed_on"], name: "index_services_on_renewed_on"
     t.index ["user_id"], name: "index_services_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_02_20_043306) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_02_053618) do
+ActiveRecord::Schema.define(version: 2020_02_20_043306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,9 +44,11 @@ ActiveRecord::Schema.define(version: 2020_02_02_053618) do
     t.integer "access_count_to_reset_password_page", default: 0
     t.boolean "mail_notification", default: false, null: false
     t.datetime "remind_sent_at"
+    t.datetime "renewal_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["remind_sent_at"], name: "index_users_on_remind_sent_at"
+    t.index ["renewal_sent_at"], name: "index_users_on_renewal_sent_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -4,7 +4,10 @@ namespace :notification do
   desc "Notify user to renewed service."
   task renewal: :environment do
     Service.includes(:user).renewal.group_by(&:user).each do |user, services|
-      UserMailer.renew_service(user, services).deliver_now if user.mail_notification
+      if user.mail_notification && !user.renewal_sent_at.try(:between?, Date.today.beginning_of_day, Date.today.end_of_day)
+        UserMailer.renew_service(user, services).deliver_now
+        user.touch(:renewal_sent_at)
+      end
     end
   end
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -3,8 +3,7 @@
 namespace :notification do
   desc "Notify user to renewed service."
   task renewal: :environment do
-    Service.renewal.includes(:user).group_by(&:user).each do |user, services|
-      services.each(&:renew!)
+    Service.includes(:user).renewal.group_by(&:user).each do |user, services|
       UserMailer.renew_service(user, services).deliver_now if user.mail_notification
     end
   end

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -11,7 +11,7 @@ class NotificationTest < ActiveSupport::TestCase
   test "renew service" do
     travel_to Time.zone.parse("2020-01-31") do
       Rake::Task["notification:renewal"].execute
-      assert_equal ActionMailer::Base.deliveries.count, 2
+      assert_equal 2, ActionMailer::Base.deliveries.count
     end
   end
 
@@ -20,24 +20,24 @@ class NotificationTest < ActiveSupport::TestCase
     user.services.create(name: "No notification", plan: 0, renewed_on: "2020-10-10")
     travel_to Time.zone.parse("2020-10-10") do
       Rake::Task["notification:renewal"].execute
-      assert_equal ActionMailer::Base.deliveries.count, 0
+      assert_equal 0, ActionMailer::Base.deliveries.count
     end
   end
 
   test "remind services" do
     travel_to Time.zone.parse("2020-12-31") do
       Rake::Task["notification:remind"].execute
-      assert_equal ActionMailer::Base.deliveries.count, 1
+      assert_equal 1, ActionMailer::Base.deliveries.count
     end
   end
 
   test "do not send emails to reminded users" do
     travel_to Time.zone.parse("2020-12-31") do
       Rake::Task["notification:remind"].execute
-      assert_equal ActionMailer::Base.deliveries.count, 1
+      assert_equal 1, ActionMailer::Base.deliveries.count
       ActionMailer::Base.deliveries.clear
       Rake::Task["notification:remind"].execute
-      assert_equal ActionMailer::Base.deliveries.count, 0
+      assert_equal 0, ActionMailer::Base.deliveries.count
     end
   end
 end

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -4,26 +4,22 @@ require "test_helper"
 
 class NotificationTest < ActiveSupport::TestCase
   setup do
+    ActionMailer::Base.deliveries.clear
     Prebill::Application.load_tasks
   end
 
   test "renew service" do
-    monthly = services(:renewal)
-    yearly = services(:other_renewal)
     travel_to Time.zone.parse("2020-01-31") do
       Rake::Task["notification:renewal"].execute
-      assert_equal Date.parse("2020-02-29"), monthly.reload.renewed_on
-      assert_equal Date.parse("2021-01-31"), yearly.reload.renewed_on
       assert_equal ActionMailer::Base.deliveries.count, 2
     end
   end
 
   test "do not send mail if user do not want to receive" do
     user = users(:inactive)
-    service = user.services.create(name: "No notification", plan: 0, renewed_on: "2020-10-10")
+    user.services.create(name: "No notification", plan: 0, renewed_on: "2020-10-10")
     travel_to Time.zone.parse("2020-10-10") do
       Rake::Task["notification:renewal"].execute
-      assert_equal Date.parse("2020-11-10"), service.reload.renewed_on
       assert_equal ActionMailer::Base.deliveries.count, 0
     end
   end

--- a/test/lib/notification_test.rb
+++ b/test/lib/notification_test.rb
@@ -15,7 +15,17 @@ class NotificationTest < ActiveSupport::TestCase
     end
   end
 
-  test "do not send mail if user do not want to receive" do
+  test "do not send email if user already receive renewal email" do
+    travel_to Time.zone.parse("2020-01-31") do
+      Rake::Task["notification:renewal"].execute
+      assert_equal 2, ActionMailer::Base.deliveries.count
+      ActionMailer::Base.deliveries.clear
+      Rake::Task["notification:renewal"].execute
+      assert_equal 0, ActionMailer::Base.deliveries.count
+    end
+  end
+
+  test "do not send email if user do not want to receive" do
     user = users(:inactive)
     user.services.create(name: "No notification", plan: 0, renewed_on: "2020-10-10")
     travel_to Time.zone.parse("2020-10-10") do

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -57,7 +57,7 @@ class ServiceTest < ActiveSupport::TestCase
   test "renewal" do
     renewal_services = services(:renewal, :other_renewal)
     travel_to Time.zone.parse("2020-01-31") do
-      assert_equal Service.renewal, renewal_services
+      assert_equal renewal_services, Service.renewal
     end
   end
 

--- a/test/models/service_test.rb
+++ b/test/models/service_test.rb
@@ -54,22 +54,51 @@ class ServiceTest < ActiveSupport::TestCase
     assert_equal 1646, user.services.monthly_average_amount
   end
 
-  test "renew!" do
-    user = users(:shoynoi)
-    monthly_service = Service.create(name: "Monthly Subscription", plan: "monthly", renewed_on: Date.today, user: user)
-    yearly_service = Service.create(name: "Yearly Subscription", plan: "yearly", renewed_on: Date.today, user: user)
-    assert_changes -> { monthly_service.renewed_on }, from: Date.today, to: Date.today.next_month do
-      monthly_service.renew!
-    end
-    assert_changes -> { yearly_service.renewed_on }, from: Date.today, to: Date.today.next_year do
-      yearly_service.renew!
-    end
-  end
-
   test "renewal" do
     renewal_services = services(:renewal, :other_renewal)
     travel_to Time.zone.parse("2020-01-31") do
       assert_equal Service.renewal, renewal_services
+    end
+  end
+
+  test "#next_renewed_on of every month" do
+    user = users(:shoynoi)
+    service = user.services.create(name: "monthly update", plan: 0, renewed_on: Date.parse("2020-10-29"), user: user)
+    travel_to Time.zone.parse("2020-10-29") do
+      assert_equal Date.parse("2020-10-29"), service.next_renewed_on
+    end
+    travel_to Time.zone.parse("2020-10-30") do
+      assert_equal Date.parse("2020-11-29"), service.next_renewed_on
+    end
+    travel_to Time.zone.parse("2020-11-30") do
+      assert_equal Date.parse("2020-12-29"), service.next_renewed_on
+    end
+  end
+
+  test "#next_renewed_on of every year" do
+    user = users(:shoynoi)
+    service = user.services.create(name: "yearly update", plan: 1, renewed_on: Date.parse("2020-02-29"), user: user)
+    travel_to Time.zone.parse("2020-02-29") do
+      assert_equal Date.parse("2020-02-29"), service.next_renewed_on
+    end
+    travel_to Time.zone.parse("2020-03-01") do
+      assert_equal Date.parse("2021-02-28"), service.next_renewed_on
+    end
+    travel_to Time.zone.parse("2023-03-01") do
+      assert_equal Date.parse("2024-02-29"), service.next_renewed_on
+    end
+  end
+
+  test "#next_renewed_on of every end of month" do
+    service = services(:renewal)
+    travel_to Time.zone.parse("2020-01-31") do
+      assert_equal Date.parse("2020-01-31"), service.next_renewed_on
+    end
+    travel_to Time.zone.parse("2020-02-01") do
+      assert_equal Date.parse("2020-02-29"), service.next_renewed_on
+    end
+    travel_to Time.zone.parse("2020-03-01") do
+      assert_equal Date.parse("2020-03-31"), service.next_renewed_on
     end
   end
 end


### PR DESCRIPTION
## 概要

- サービスの更新日(renewed_on)に自動で更新日をアップデートしていた処理を削除
- モデルに次回の更新日を算出するメソッドを追加
- 更新日にメール通知を受け取る設定をしているユーザーに対して、重複してメールが送信されないように`renewal_sent_at`カラムを追加
- テストを追加/修正