### PR TITLE
プリセットサービスのプランと料金のバリデーションを外した

### DIFF
--- a/app/models/preset_service.rb
+++ b/app/models/preset_service.rb
@@ -2,6 +2,4 @@
 
 class PresetService < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-  validates :plan, presence: true
-  validates :price, presence: true
 end


### PR DESCRIPTION
## 概要

- PresetServiceモデルのプランと料金のバリデーションを外した
    - すべてのプラン・料金に対応できていないときにはサービス名のみを補完したいため